### PR TITLE
Reduce default keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ There are 4 modes of operation:
 
     On the first run, arch-manwarn assumes you have already read and handled all previous manual interventions.
 
-By default it classifies Arch news as requiring manual intervention with the keywords:
+arch-manwarn flags news containing "manual intervention" (case-insensitive) as requiring action.
+You can customize keywords in ~/.config/arch-manwarn/config.toml:
 
--   `manual intervention`
--   `action required`
--   `attention`
--   `intervention`
+```
+keywords = ["manual intervention", "breaking change"]
+```
 
 Originally, this was planned to be interactive, but pacman hooks are inherently not designed for this behavior.
 
@@ -73,7 +73,7 @@ Example `config.toml` with default options
 
 ```
 # List of keywords to match in news entry titles
-keywords = ["manual intervention", "action required", "attention", "intervention"]
+keywords = ["manual intervention",]
 
 # If true, show *all* news entries regardless of keywords
 match_all_entries = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,10 +62,7 @@ impl Default for Config {
         Self {
             cache_path: "/var/cache/arch-manwarn.json".to_string(),
             rss_feed_url: "https://archlinux.org/feeds/news/".to_string(),
-            keywords: vec!["manual intervention".to_string(),
-                            "action required".to_string(),
-                            "attention".to_string(),
-                            "intervention".to_string()],
+            keywords: vec!["manual intervention".to_string()],
             ignored_keywords: vec![],
             include_summary_in_query: true,
             prune_missing_days: 30,


### PR DESCRIPTION
Did this because v0.8.1 caused an irrelevant article to be classified as manual intervention