### PR TITLE
Remove some dependency, adjust tokio runtime initialize time, add config to use 'content' as summary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,37 +18,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "arch-manwarn"
 version = "1.0.0"
 dependencies = [
- "feed-rs",
  "html2text",
  "once_cell",
  "reqwest",
+ "rss",
  "serde",
  "serde_json",
  "tokio",
@@ -116,21 +92,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
-name = "chrono"
-version = "0.4.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "serde",
- "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,7 +140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -187,23 +148,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "feed-rs"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c0591d23efd0d595099af69a31863ac1823046b1b021e3b06ba3aae7e00991"
-dependencies = [
- "chrono",
- "mediatype",
- "quick-xml",
- "regex",
- "serde",
- "serde_json",
- "siphasher",
- "url",
- "uuid",
-]
 
 [[package]]
 name = "fnv"
@@ -423,30 +367,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -672,15 +592,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mediatype"
-version = "0.19.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33746aadcb41349ec291e7f2f0a3aa6834d1d7c58066fb4b01f68efc4c4b7631"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,15 +639,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "object"
@@ -956,35 +858,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
 name = "reqwest"
 version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +894,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rss"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2107738f003660f0a91f56fd3e3bd3ab5d918b2ddaf1e1ec2136fb1c46f71bf"
+dependencies = [
+ "quick-xml",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,7 +918,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1257,7 +1139,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1470,7 +1352,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]
@@ -1484,17 +1365,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "uuid"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
-dependencies = [
- "getrandom",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "vcpkg"
@@ -1617,65 +1487,6 @@ dependencies = [
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,6 @@ name = "arch-manwarn"
 version = "1.0.0"
 dependencies = [
  "feed-rs",
- "futures",
  "html2text",
  "once_cell",
  "reqwest",
@@ -247,28 +246,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -276,40 +259,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -323,16 +272,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,8 @@ strip = "symbols"
 
 
 [dependencies]
-reqwest = { version = "0.12.22", default-features = false, features = ["json", "native-tls"] }
+reqwest = { version = "0.12.22", default-features = false, features = [ "native-tls"] }
 tokio = { version = "1.46.1", features = ["rt-multi-thread", "macros"] }
-futures = "0.3.31"
 feed-rs = "2.3.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ strip = "symbols"
 [dependencies]
 reqwest = { version = "0.12.22", default-features = false, features = [ "native-tls"] }
 tokio = { version = "1.46.1", features = ["rt-multi-thread", "macros"] }
-feed-rs = "2.3.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 once_cell = "1.21.3"
 toml = "0.9.2"
 html2text = "0.15.2"
+rss = { version = "2.0.12", default-features = false }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,8 +1,8 @@
+use crate::config::CONFIG;
+use crate::rss::{self, ManualInterventionResult};
 use std::fs;
 use std::path::Path;
-use crate::{rss::{self, ManualInterventionResult}};
 use std::time::{SystemTime, UNIX_EPOCH};
-use crate::config::CONFIG;
 
 pub fn get_cache_path() -> String {
     std::env::var("ARCH_NEWS_CACHE_PATH")
@@ -52,18 +52,21 @@ pub fn current_unix_time() -> i64 {
 fn save_cache(cache_path: String, cache_file: CacheFile) {
     if let Some(parent) = Path::new(&cache_path).parent() {
         if let Err(e) = fs::create_dir_all(parent) {
-            eprintln!("Failed to create cache directory {:?}: {}", parent, e);
+            eprintln!("Failed to create cache directory {parent:?}: {e}");
         }
     }
-    if let Err(e) = fs::write(&cache_path, serde_json::to_string_pretty(&cache_file).unwrap()) {
-        eprintln!("Failed to write cache file {}: {}", cache_path, e);
+    if let Err(e) = fs::write(
+        &cache_path,
+        serde_json::to_string_pretty(&cache_file).unwrap(),
+    ) {
+        eprintln!("Failed to write cache file {cache_path}: {e}");
         eprintln!("Try running the program as root or with sudo if you want to use /var/cache.");
     }
 }
 
 pub fn load_cache(cache_path: &str) -> CacheFile {
     // Load previously cached entries
-    let cache_file: CacheFile = if let Ok(data) = fs::read_to_string(&cache_path) {
+    let cache_file: CacheFile = if let Ok(data) = fs::read_to_string(cache_path) {
         serde_json::from_str(&data).unwrap_or_default()
     } else {
         CacheFile::default()
@@ -94,8 +97,7 @@ pub fn check_new_entries(force_mark_as_read: bool) -> Vec<CachedEntry> {
             if seconds > 86400 {
                 let days = seconds as f64 / 86400.0;
                 eprintln!(
-                    "Warning: last successful connection to the RSS feed(s) was {:.1} days ago.",
-                    days
+                    "Warning: last successful connection to the RSS feed(s) was {days:.1} days ago."
                 );
             }
         }
@@ -161,5 +163,9 @@ pub fn check_new_entries(force_mark_as_read: bool) -> Vec<CachedEntry> {
 
     // If this is the first run, return an empty vector
     // Otherwise, return the new entries found
-    if first_run { Vec::new() } else { new_entries }
+    if first_run {
+        Vec::new()
+    } else {
+        new_entries
+    }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -72,8 +72,8 @@ pub fn load_cache(cache_path: &str) -> CacheFile {
     cache_file
 }
 
-pub async fn check_new_entries(force_mark_as_read: bool) -> Vec<CachedEntry> {
-    let result: ManualInterventionResult = rss::check_for_manual_intervention().await;
+pub fn check_new_entries(force_mark_as_read: bool) -> Vec<CachedEntry> {
+    let result: ManualInterventionResult = rss::check_for_manual_intervention();
     let cache_path = get_cache_path();
 
     // Determining whether this is the first run

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,9 @@
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use std::env;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use once_cell::sync::Lazy;
-use std::env;
-
 
 pub fn config_path() -> PathBuf {
     // For development: ARCH_MANWARN_CONFIG=/path/to/custom/config.toml
@@ -79,16 +78,15 @@ impl Default for Config {
 
 impl Config {
     pub fn load_from_file(path: &Path) -> Result<Self, String> {
-        let content = fs::read_to_string(path)
-            .map_err(|e| format!("Failed to read config file: {e}"))?;
+        let content =
+            fs::read_to_string(path).map_err(|e| format!("Failed to read config file: {e}"))?;
 
-        let config: Config = toml::from_str(&content)
-            .map_err(|e| format!("Failed to parse config file: {e}"))?;
+        let config: Config =
+            toml::from_str(&content).map_err(|e| format!("Failed to parse config file: {e}"))?;
 
         let updated = toml::to_string_pretty(&config)
             .map_err(|e| format!("Failed to serialize updated config: {e}"))?;
-        fs::write(path, updated)
-            .map_err(|e| format!("Failed to write updated config: {e}"))?;
+        fs::write(path, updated).map_err(|e| format!("Failed to write updated config: {e}"))?;
 
         Ok(config)
     }
@@ -121,4 +119,4 @@ impl Config {
     }
 }
 
-pub static CONFIG: Lazy<Config> = Lazy::new(|| Config::load());
+pub static CONFIG: Lazy<Config> = Lazy::new(Config::load);

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,8 @@ pub struct Config {
     /// If false, only title and link will be shown
     pub show_summary: bool,
 
+    pub replace_description_with_content: bool,
+
     /// Whether to automatically mark as read after blocking
     pub mark_as_read_automatically: bool,
 
@@ -70,6 +72,7 @@ impl Default for Config {
             prune_age_days: 60,
             match_all_entries: false,
             show_summary: false,
+            replace_description_with_content: false,
             mark_as_read_automatically: true,
             warn_only: false,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
-mod rss;
 mod cache;
 mod config;
+mod rss;
 use crate::config::CONFIG;
 
 fn main() {
@@ -25,9 +25,9 @@ fn main() {
                 eprintln!("\nMatched the following Arch news entries:\n");
                 if !CONFIG.show_summary {
                     for entry in &new_entries {
-                    eprintln!("- {}", entry.title);
-                    eprintln!("  For more details see: {}", entry.link);
-                    eprintln!("---")
+                        eprintln!("- {}", entry.title);
+                        eprintln!("  For more details see: {}", entry.link);
+                        eprintln!("---")
                     }
                 } else {
                     for entry in &new_entries {
@@ -39,7 +39,9 @@ fn main() {
                 eprintln!("\nAll other news can be found on https://archlinux.org/news/.");
 
                 if CONFIG.warn_only {
-                    eprintln!("Arch ManWarn: Warning only mode is enabled — not blocking upgrade.\n");
+                    eprintln!(
+                        "Arch ManWarn: Warning only mode is enabled — not blocking upgrade.\n"
+                    );
                 } else {
                     eprintln!("Arch ManWarn: Exiting to block the upgrade process.\n");
                     std::process::exit(1);
@@ -52,10 +54,7 @@ fn main() {
             if new_entries.is_empty() {
                 println!("No unseen entries — nothing to mark as read.");
             } else {
-                println!(
-                    "Marked {} entries as manually read.",
-                    new_entries.len()
-                );
+                println!("Marked {} entries as manually read.", new_entries.len());
             }
         }
 
@@ -95,14 +94,14 @@ fn main() {
 
                 println!(
                     "- {} (first seen {:.1} day(s) ago, last seen {:.1} day(s) ago)",
-                    entry.title,
-                    days_since_first_seen,
-                    days_since_last_seen
+                    entry.title, days_since_first_seen, days_since_last_seen
                 );
             }
 
             if let Some(ts) = cache_file.last_successful_request {
-                let days = days_ago_float(ts.duration_since(std::time::UNIX_EPOCH).unwrap().as_secs() as i64);
+                let days = days_ago_float(
+                    ts.duration_since(std::time::UNIX_EPOCH).unwrap().as_secs() as i64,
+                );
                 println!(
                     "\nLast successful feed request: {:.1} day{} ago.",
                     days,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,7 @@ mod cache;
 mod config;
 use crate::config::CONFIG;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let mut args = std::env::args();
     let _exe = args.next();
 
@@ -21,7 +20,7 @@ async fn main() {
         }
 
         Some("check") => {
-            let new_entries = cache::check_new_entries(false).await;
+            let new_entries = cache::check_new_entries(false);
             if !new_entries.is_empty() {
                 eprintln!("\nMatched the following Arch news entries:\n");
                 if !CONFIG.show_summary {
@@ -47,7 +46,7 @@ async fn main() {
         }
 
         Some("read") => {
-            let new_entries = cache::check_new_entries(true).await;
+            let new_entries = cache::check_new_entries(true);
             if new_entries.is_empty() {
                 println!("No unseen entries — nothing to mark as read.");
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,11 +27,13 @@ fn main() {
                     for entry in &new_entries {
                     eprintln!("- {}", entry.title);
                     eprintln!("  For more details see: {}", entry.link);
+                    eprintln!("---")
                     }
                 } else {
                     for entry in &new_entries {
                         eprintln!("- {}", entry.title);
-                        eprintln!("\nSummary: \n{}", entry.summary)
+                        eprintln!("\nSummary: \n{}", entry.summary);
+                        eprintln!("---")
                     }
                 }
                 eprintln!("\nAll other news can be found on https://archlinux.org/news/.");

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -53,7 +53,7 @@ pub fn check_for_manual_intervention() -> ManualInterventionResult {
 
     // Check for entries with keywords that indicate manual intervention
     let keywords: Vec<String> = if CONFIG.case_sensitive {
-        CONFIG.keywords.iter().cloned().collect()
+        CONFIG.keywords.to_vec()
     } else {
         CONFIG
             .keywords
@@ -82,11 +82,10 @@ pub fn check_for_manual_intervention() -> ManualInterventionResult {
                 text.to_ascii_lowercase()
             };
 
-            if keywords.iter().any(|kw| text_to_check.contains(kw)) {
-                if !ignored_keywords(entry) {
+            if keywords.iter().any(|kw| text_to_check.contains(kw))
+                && !ignored_keywords(entry) {
                     found_entries.push(entry.clone());
                 }
-            }
         }
     } else {
         for entry in &entries {
@@ -104,7 +103,7 @@ pub fn check_for_manual_intervention() -> ManualInterventionResult {
 
     ManualInterventionResult {
         entries: found_entries,
-        last_successful_request: last_successful_request,
+        last_successful_request,
     }
 }
 
@@ -136,12 +135,12 @@ async fn fetch_and_parse_single_feed(client: Client, url: &str) -> Vec<NewsEntry
         Ok(response) => match response.text().await {
             Ok(text) => text,
             Err(err) => {
-                eprintln!("Failed to read response text from {}: {err}", url);
+                eprintln!("Failed to read response text from {url}: {err}");
                 return Vec::new();
             }
         },
         Err(err) => {
-            eprintln!("Failed to fetch RSS feed {}: {err}", url);
+            eprintln!("Failed to fetch RSS feed {url}: {err}");
             return Vec::new();
         }
     };
@@ -149,7 +148,7 @@ async fn fetch_and_parse_single_feed(client: Client, url: &str) -> Vec<NewsEntry
     let channel = match rss::Channel::from_str(&content) {
         Ok(ch) => ch,
         Err(err) => {
-            eprintln!("Failed to parse feed {}: {err}", url);
+            eprintln!("Failed to parse feed {url}: {err}");
             return Vec::new();
         }
     };

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -47,10 +47,9 @@ pub fn ignored_keywords(entry: &NewsEntry) -> bool {
     false
 }
 
-pub async fn check_for_manual_intervention() -> ManualInterventionResult {
+pub fn check_for_manual_intervention() -> ManualInterventionResult {
     // This gives us a vector of NewsEntry structs from the archlinux.org RSS feed
     let start_time = SystemTime::now();
-    let entries = get_entries_from_feeds();
 
     // Check for entries with keywords that indicate manual intervention
     let keywords: Vec<String> = if CONFIG.case_sensitive {
@@ -66,7 +65,8 @@ pub async fn check_for_manual_intervention() -> ManualInterventionResult {
 
     // Biggest performance overhead is here:
     // This is where the actual network request to the feed is awaited
-    let entries = entries.await;
+    // Include tokio runtime initializing
+    let entries = get_entries_from_feeds();
 
     if !CONFIG.match_all_entries {
         for entry in &entries {
@@ -108,6 +108,7 @@ pub async fn check_for_manual_intervention() -> ManualInterventionResult {
     }
 }
 
+#[tokio::main]
 pub async fn get_entries_from_feeds() -> Vec<NewsEntry> {
     let client = Client::builder()
         .user_agent("arch-manwarn")

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -82,10 +82,9 @@ pub fn check_for_manual_intervention() -> ManualInterventionResult {
                 text.to_ascii_lowercase()
             };
 
-            if keywords.iter().any(|kw| text_to_check.contains(kw))
-                && !ignored_keywords(entry) {
-                    found_entries.push(entry.clone());
-                }
+            if keywords.iter().any(|kw| text_to_check.contains(kw)) && !ignored_keywords(entry) {
+                found_entries.push(entry.clone());
+            }
         }
     } else {
         for entry in &entries {
@@ -157,10 +156,12 @@ async fn fetch_and_parse_single_feed(client: Client, url: &str) -> Vec<NewsEntry
         .into_iter()
         .map(|entry| {
             let title = entry.title.unwrap_or("[No title provided]".to_owned());
-            let summary = entry
-                .description
-                .as_deref()
-                .unwrap_or("[No summary provided]");
+            let summary = if CONFIG.replace_description_with_content {
+                entry.content
+            } else {
+                entry.description
+            };
+            let summary = summary.as_deref().unwrap_or("[No summary provided]");
             let link = entry.link.unwrap_or("[No link provided]".to_owned());
 
             NewsEntry {


### PR DESCRIPTION
- replace `feed-rs` with `rss`
- replace `futures::future::join_all` with `tokio::task::JoinSet`
- remove unnecessary feature `json` for `reqwest`
- move `#[tokio:main]` to `rss.rs:fn get_entries_from_feeds`
- new config item `replace_description_with_content`

`replace_description_with_content` is used for rss sources which place the full text in `content` rather `description` (like archlinuxcn)

---

I have another branch working on minimize the binary size, but since it's blocking, its audience is obvious