### PR TITLE
New feature: bypass next check

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -112,12 +112,12 @@ impl Config {
         let content =
             fs::read_to_string(path).map_err(|e| format!("Failed to read config file: {e}"))?;
 
-        let mut config_value: toml::Value = toml::from_str(&content)
-            .map_err(|e| format!("Failed to parse config file: {e}"))?;
+        let mut config_value: toml::Value =
+            toml::from_str(&content).map_err(|e| format!("Failed to parse config file: {e}"))?;
 
         let default = toml::Value::try_from(Config::default())
             .expect("Default config should serialize to toml::Value");
-        
+
         // Save to check if something has changed later
         let original_value = config_value.clone();
 
@@ -127,8 +127,7 @@ impl Config {
         // If the original value is different from the merged value,
         // it means some fields were missing or had wrong types,
         // and we write the updated config back to the file.
-        if &original_value != &config_value {
-            
+        if original_value != config_value {
             // Now try to deserialize the merged value
             let config: Config = config_value
                 .try_into()
@@ -138,7 +137,7 @@ impl Config {
             let updated = toml::to_string_pretty(&config)
                 .map_err(|e| format!("Failed to serialize updated config: {e}"))?;
             fs::write(path, updated).map_err(|e| format!("Failed to write updated config: {e}"))?;
-        
+
             Ok(config)
         } else {
             // If no changes were made, just deserialize the original value
@@ -150,7 +149,7 @@ impl Config {
     }
 
     /// Loads the configuration from the given file path.
-    /// 
+    ///
     /// - If the file does not exist, it creates a new config file with default values and returns those defaults.
     /// - If the file exists but is invalid TOML, prints an error and returns defaults (does not overwrite the file).
     /// - If the file is valid TOML but missing or has invalid fields, those fields are reset to defaults and the file is updated.

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,10 @@ fn main() {
             } else {
                 println!("\nLast successful feed request: never.");
             }
+
+            if cache_file.bypass_next_check {
+                println!("\nWarning:Next check will be bypassed");
+            }
         }
 
         Some("bypass") => {
@@ -132,7 +136,8 @@ fn main() {
                 arch-manwarn            - Shows a short confirmation message.
                 arch-manwarn check      - Checks for new matching Arch news entries.
                 arch-manwarn status     - Displays summary of cached entries.
-                arch-manwarn read       - Marks all entries as read."
+                arch-manwarn read       - Marks all entries as read.
+                arch-manwarn bypass     - Bypass next check"
             );
             std::process::exit(2);
         }

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -158,12 +158,14 @@ async fn fetch_and_parse_single_feed(url: &str) -> Vec<NewsEntry> {
                     }
                 }
             } else {
-                eprintln!("Failed to fetch RSS feed {current_url}: HTTP status {}", response.status());
+                eprintln!(
+                    "Failed to fetch RSS feed {current_url}: HTTP status {}",
+                    response.status()
+                );
                 return Vec::new();
             }
         }
     };
-
 
     let channel = match rss::Channel::from_str(&content) {
         Ok(ch) => ch,
@@ -177,13 +179,17 @@ async fn fetch_and_parse_single_feed(url: &str) -> Vec<NewsEntry> {
         .items
         .into_iter()
         .map(|entry| {
-            let title = entry.title.unwrap_or_else(|| "[No title provided]".to_string());
+            let title = entry
+                .title
+                .unwrap_or_else(|| "[No title provided]".to_string());
             let summary = match (entry.content, entry.description) {
                 (None, None) => "[No summary provided]".to_string(),
                 (Some(c), Some(d)) if c.len() > d.len() => c,
                 (_, Some(s)) | (Some(s), None) => s,
             };
-            let link = entry.link.unwrap_or_else(|| "[No link provided]".to_string());
+            let link = entry
+                .link
+                .unwrap_or_else(|| "[No link provided]".to_string());
 
             NewsEntry {
                 title,


### PR DESCRIPTION
There are times when pacman download packages from a mirror, while `arch-manwarn` stuck on poor network to archlinux.org. The default timeout is long, so I come up with this idea.

This flag is stored in cache file, and can be added by `arch-manwarn bypass` and automatically remove by `arch-manwarn check` (with prompt 'This check is bypassed!')

I also refactor some logic around `CacheFile`.

---

```
> arch-manwarn bypass
Next check will be bypassed!

> arch-manwarn check
This check is bypassed!

> arch-manwarn check
...
```